### PR TITLE
Add MiniMax text-to-image support

### DIFF
--- a/.claude/skills/ai-image-creator/SKILL.md
+++ b/.claude/skills/ai-image-creator/SKILL.md
@@ -25,6 +25,10 @@ When the user mentions a model keyword in their image request, use the correspon
 | `gpt5` | [OpenAI GPT-5 Image](https://openrouter.ai/openai/gpt-5-image) | "gpt5", "gpt5 image", "use gpt5" |
 | `gpt5.4` | [OpenAI GPT-5.4 Image 2](https://openrouter.ai/openai/gpt-5.4-image-2) | "gpt5.4", "gpt-5.4 image", "use gpt5.4" |
 
+MiniMax text-to-image generation is available directly with `--provider minimax`.
+It defaults to the global endpoint and `image-01`; use `--minimax-region cn` for
+the China endpoint or `-m image-01-live` for the live model.
+
 ## Instructions
 
 > **Routing check:** If the user asks to **describe, analyze, or explain an existing image** (not generate a new one), skip directly to the **Image Analysis (`--analyze`)** section below. No prompt enhancement or output path needed.
@@ -101,6 +105,18 @@ uv run python ${CLAUDE_SKILL_DIR}/scripts/generate-image.py \
   [-t]
 ```
 
+With MiniMax:
+
+```bash
+uv run python ${CLAUDE_SKILL_DIR}/scripts/generate-image.py \
+  --provider minimax \
+  --minimax-region global \
+  --response-format url \
+  -m image-01 \
+  -o "OUTPUT_PATH" \
+  -p "A serene mountain lake at sunset"
+```
+
 With a specific model:
 ```bash
 uv run python ${CLAUDE_SKILL_DIR}/scripts/generate-image.py \
@@ -157,7 +173,13 @@ If the user needs resizing, format conversion, or other manipulation, first dete
 | `--output` | `-o` | Yes | -- | Output file path (parent dirs auto-created) |
 | `--prompt` | `-p` | No | -- | Inline prompt text |
 | `--prompt-file` | -- | No | `../tmp/prompt.txt` | Path to prompt file |
-| `--provider` | -- | No | `openrouter` | `openrouter` or `google` |
+| `--provider` | -- | No | `openrouter` | `openrouter`, `google`, or `minimax` |
+| `--minimax-region` | -- | No | `global` | MiniMax endpoint region: `global` or `cn` |
+| `--response-format` | -- | No | `url` | MiniMax output format: `url` or `base64` |
+| `--width` / `--height` | -- | No | -- | MiniMax image dimensions; provide both together |
+| `--seed` | -- | No | -- | MiniMax generation seed |
+| `--num-images` | -- | No | -- | MiniMax image count (`n`) |
+| `--prompt-optimizer` | -- | No | -- | Enable MiniMax prompt optimization; use `--no-prompt-optimizer` to disable |
 | `--aspect-ratio` | `-a` | No | model default | OpenRouter only: `1:1`, `16:9`, `9:16`, `3:2`, `2:3`, `4:3`, `3:4`, `4:5`, `5:4`, `21:9` |
 | `--image-size` | `-s` | No | model default | OpenRouter only: `1K`, `2K`, `4K`. `0.5K` is accepted **only** on the Gemini 3.1 Flash preview build (`-m google/gemini-3.1-flash-image-preview-20260226`); every selectable keyword rejects it |
 | `--model` | `-m` | No | `gemini` | Model keyword (`gemini`, `geminipro`, `riverflow`, `flux2`, `seedream`, `gpt5`, `gpt5.4`) or full model ID |
@@ -180,6 +202,7 @@ If the user needs resizing, format conversion, or other manipulation, first dete
 | `AI_IMG_CREATOR_CF_TOKEN` | Gateway mode | Gateway auth token |
 | `AI_IMG_CREATOR_OPENROUTER_KEY` | Direct OpenRouter | OpenRouter API key (`sk-or-...`) |
 | `AI_IMG_CREATOR_GEMINI_KEY` | Direct Google | Google AI Studio API key |
+| `AI_IMG_CREATOR_MINIMAX_KEY` | Direct MiniMax | MiniMax API key |
 
 Gateway mode activates when all 3 `CF_*` vars are set. Falls back to direct mode if gateway fails.
 

--- a/.claude/skills/ai-image-creator/SKILL.md
+++ b/.claude/skills/ai-image-creator/SKILL.md
@@ -176,6 +176,7 @@ If the user needs resizing, format conversion, or other manipulation, first dete
 | `--provider` | -- | No | `openrouter` | `openrouter`, `google`, or `minimax` |
 | `--minimax-region` | -- | No | `global` | MiniMax endpoint region: `global` or `cn` |
 | `--response-format` | -- | No | `url` | MiniMax output format: `url` or `base64` |
+| `--subject-reference` | -- | No | -- | MiniMax subject reference image URL (repeatable) |
 | `--width` / `--height` | -- | No | -- | MiniMax image dimensions; provide both together |
 | `--seed` | -- | No | -- | MiniMax generation seed |
 | `--num-images` | -- | No | -- | MiniMax image count (`n`) |

--- a/.claude/skills/ai-image-creator/references/api-reference.md
+++ b/.claude/skills/ai-image-creator/references/api-reference.md
@@ -79,6 +79,36 @@ PNG, JPEG, WebP, GIF. Images are base64-encoded inline (data URLs for OpenRouter
 
 ## Providers & Endpoints
 
+### MiniMax
+
+MiniMax text-to-image generation uses `POST /v1/image_generation` with Bearer
+authentication. Select the endpoint with `--minimax-region`:
+
+| Region | Endpoint |
+|---|---|
+| `global` | `https://api.minimax.io/v1/image_generation` |
+| `cn` | `https://api.minimaxi.com/v1/image_generation` |
+
+Supported models are `image-01` (default) and `image-01-live`. The request
+requires `model` and `prompt`; optional controls include `aspect_ratio`,
+`width`, `height`, `response_format`, `seed`, `n`, and `prompt_optimizer`.
+Choose `url` or `base64` with `--response-format`. URL results expire after
+24 hours, so the script downloads the first result before returning.
+
+```json
+{
+  "model": "image-01",
+  "prompt": "A lighthouse at dawn",
+  "aspect_ratio": "16:9",
+  "response_format": "url",
+  "n": 1,
+  "prompt_optimizer": true
+}
+```
+
+The response decoder reads `data.image_urls`, verifies
+`base_resp.status_code`, and accepts either a remote URL or base64 image data.
+
 ### OpenRouter (via CF AI Gateway)
 
 **Gateway URL:**

--- a/.claude/skills/ai-image-creator/references/api-reference.md
+++ b/.claude/skills/ai-image-creator/references/api-reference.md
@@ -90,8 +90,10 @@ authentication. Select the endpoint with `--minimax-region`:
 | `cn` | `https://api.minimaxi.com/v1/image_generation` |
 
 Supported models are `image-01` (default) and `image-01-live`. The request
-requires `model` and `prompt`; optional controls include `aspect_ratio`,
-`width`, `height`, `response_format`, `seed`, `n`, and `prompt_optimizer`.
+requires `model` and `prompt`; optional controls include `subject_reference`,
+`aspect_ratio`, `width`, `height`, `response_format`, `seed`, `n`, and
+`prompt_optimizer`. Add one or more HTTPS subject images with repeatable
+`--subject-reference` arguments.
 Choose `url` or `base64` with `--response-format`. URL results expire after
 24 hours, so the script downloads the first result before returning.
 

--- a/.claude/skills/ai-image-creator/references/setup-guide.md
+++ b/.claude/skills/ai-image-creator/references/setup-guide.md
@@ -7,7 +7,7 @@ Step-by-step instructions to configure all required services for the ai-image-cr
 - **uv** (Python runner): Install via `curl -LsSf https://astral.sh/uv/install.sh | sh` or `brew install uv`
 - **Python 3.10+**: Bundled with uv or install separately
 - A Cloudflare account (free tier works)
-- An OpenRouter account and/or Google AI Studio account
+- An account for at least one supported API provider
 
 ### Optional (for transparent mode `-t`)
 
@@ -89,6 +89,10 @@ Store your API keys securely in Cloudflare so they're never sent in request head
 
 Add these to your shell profile or system environment variables.
 
+For direct MiniMax generation, create an API key in the global or China
+MiniMax platform console and set `AI_IMG_CREATOR_MINIMAX_KEY`. MiniMax requests
+are sent directly; they do not use the gateway settings below.
+
 ### macOS / Linux
 
 Edit `~/.zshrc` (macOS) or `~/.bashrc` (Linux):
@@ -102,6 +106,7 @@ export AI_IMG_CREATOR_CF_TOKEN="your-gateway-auth-token"
 # AI Image Creator — Direct API keys (fallback, optional if BYOK configured)
 export AI_IMG_CREATOR_OPENROUTER_KEY="sk-or-your-key-here"
 export AI_IMG_CREATOR_GEMINI_KEY="AIyour-key-here"
+export AI_IMG_CREATOR_MINIMAX_KEY="your-minimax-key-here"
 ```
 
 Apply changes:
@@ -124,6 +129,7 @@ Set environment variables via PowerShell (user-level, persists across sessions):
 # AI Image Creator — Direct API keys (fallback, optional if BYOK configured)
 [Environment]::SetEnvironmentVariable("AI_IMG_CREATOR_OPENROUTER_KEY", "sk-or-your-key-here", "User")
 [Environment]::SetEnvironmentVariable("AI_IMG_CREATOR_GEMINI_KEY", "AIyour-key-here", "User")
+[Environment]::SetEnvironmentVariable("AI_IMG_CREATOR_MINIMAX_KEY", "your-minimax-key-here", "User")
 ```
 
 Or use **Settings > System > About > Advanced system settings > Environment Variables** to add them via the GUI.
@@ -194,6 +200,14 @@ Then ask: "Generate a simple blue circle on white background" with output to `te
 
 **Expected result:** A PNG file is created. The script outputs the file path and size.
 
+To verify MiniMax directly:
+
+```bash
+uv run python .claude/skills/ai-image-creator/scripts/generate-image.py \
+  --provider minimax --minimax-region global -m image-01 \
+  -p "A simple blue circle on white background" -o test-image.png
+```
+
 **Clean up test file:**
 ```bash
 rm test-image.png
@@ -208,7 +222,7 @@ Environment variables are not set or not exported. Run `echo $AI_IMG_CREATOR_CF_
 
 ### "HTTP 401: Unauthorized"
 - **Gateway mode:** Check `AI_IMG_CREATOR_CF_TOKEN` is correct. Regenerate in CF dashboard if needed.
-- **Direct mode:** Check `AI_IMG_CREATOR_OPENROUTER_KEY` or `AI_IMG_CREATOR_GEMINI_KEY`.
+- **Direct mode:** Check the API key environment variable for the selected provider.
 
 ### "uv: command not found"
 Install uv: `curl -LsSf https://astral.sh/uv/install.sh | sh` or `brew install uv`

--- a/.claude/skills/ai-image-creator/scripts/generate-image.py
+++ b/.claude/skills/ai-image-creator/scripts/generate-image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""AI Image Generator — Generate PNG images via multiple OpenRouter models or Google AI Studio.
+"""AI Image Generator — Generate PNG images through supported API providers.
 
 Supports multiple image generation models via keyword shortcuts:
     gemini     — Google Gemini 3.1 Flash (default, multimodal)
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import json
 import logging
 import os
@@ -48,6 +49,13 @@ from typing import Any  # noqa: F401 — used in type hints below
 DEFAULT_MODELS = {
     "openrouter": "google/gemini-3.1-flash-image",
     "google": "gemini-3.1-flash-image",
+    "minimax": "image-01",
+}
+
+MINIMAX_MODELS = {"image-01", "image-01-live"}
+MINIMAX_ENDPOINTS = {
+    "global": "https://api.minimax.io/v1/image_generation",
+    "cn": "https://api.minimaxi.com/v1/image_generation",
 }
 
 # Model registry — maps keyword shortcuts to model metadata.
@@ -291,6 +299,7 @@ ENV_CF_GATEWAY_ID = "AI_IMG_CREATOR_CF_GATEWAY_ID"
 ENV_CF_TOKEN = "AI_IMG_CREATOR_CF_TOKEN"
 ENV_OPENROUTER_KEY = "AI_IMG_CREATOR_OPENROUTER_KEY"
 ENV_GEMINI_KEY = "AI_IMG_CREATOR_GEMINI_KEY"
+ENV_MINIMAX_KEY = "AI_IMG_CREATOR_MINIMAX_KEY"
 # Cloudflare AI Gateway BYOK aliases — the names the stored provider keys live
 # under in CF. setup-guide.md instructs "aistudio" for Google AI Studio and
 # "default" for OpenRouter; override here if different aliases were used.
@@ -302,7 +311,7 @@ ENV_CF_BYOK_ALIAS_OPENROUTER = "AI_IMG_CREATOR_CF_BYOK_ALIAS_OPENROUTER"  # Open
 # working directory could otherwise inject arbitrary env vars.
 _CWD_DOTENV_ALLOWED_KEYS = {
     ENV_CF_ACCOUNT_ID, ENV_CF_GATEWAY_ID, ENV_CF_TOKEN,
-    ENV_OPENROUTER_KEY, ENV_GEMINI_KEY,
+    ENV_OPENROUTER_KEY, ENV_GEMINI_KEY, ENV_MINIMAX_KEY,
     ENV_CF_BYOK_ALIAS, ENV_CF_BYOK_ALIAS_OPENROUTER,
 }
 
@@ -403,13 +412,24 @@ def resolve_model(model_arg: str | None, provider: str) -> tuple[str, list[str]]
 
     Args:
         model_arg: The --model CLI value (keyword, full model ID, or None).
-        provider: Either 'openrouter' or 'google'.
+        provider: Selected API provider.
 
     Returns:
         Tuple of (model_id, modalities_list) where model_id is the full
         OpenRouter model identifier and modalities_list is the correct
         modalities array for the API request.
     """
+    if provider == "minimax":
+        model_id = model_arg or DEFAULT_MODELS[provider]
+        if model_id not in MINIMAX_MODELS:
+            valid = ", ".join(sorted(MINIMAX_MODELS))
+            print(
+                f"ERROR: unknown MiniMax image model '{model_id}'. Valid models: {valid}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return model_id, ["image"]
+
     if model_arg is None:
         model_id = DEFAULT_MODELS[provider]
         if provider == "openrouter":
@@ -559,9 +579,31 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--provider",
-        choices=["openrouter", "google"],
+        choices=["openrouter", "google", "minimax"],
         default="openrouter",
         help="API provider (default: openrouter)",
+    )
+    parser.add_argument(
+        "--minimax-region",
+        choices=["global", "cn"],
+        default="global",
+        help="MiniMax API region (default: global)",
+    )
+    parser.add_argument(
+        "--response-format",
+        choices=["url", "base64"],
+        default="url",
+        help="MiniMax response format (default: url)",
+    )
+    parser.add_argument("--width", type=int, default=None, help="MiniMax image width")
+    parser.add_argument("--height", type=int, default=None, help="MiniMax image height")
+    parser.add_argument("--seed", type=int, default=None, help="MiniMax generation seed")
+    parser.add_argument("--num-images", type=int, default=None, help="MiniMax image count")
+    parser.add_argument(
+        "--prompt-optimizer",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Enable or disable MiniMax prompt optimization",
     )
     parser.add_argument(
         "-a", "--aspect-ratio",
@@ -715,7 +757,7 @@ def detect_mode(provider: str) -> tuple[str, dict[str, str]]:
     """Detect gateway vs direct mode based on available env vars.
 
     Args:
-        provider: Either 'openrouter' or 'google'.
+        provider: Selected API provider.
 
     Returns:
         Tuple of (mode, config) where mode is 'gateway' or 'direct' and
@@ -724,6 +766,17 @@ def detect_mode(provider: str) -> tuple[str, dict[str, str]]:
     Raises:
         SystemExit: If no credentials are configured for the provider.
     """
+    if provider == "minimax":
+        direct_key = os.environ.get(ENV_MINIMAX_KEY, "").strip()
+        log.debug(
+            f"Env check: {ENV_MINIMAX_KEY}="
+            f"{'set (' + mask_key(direct_key) + ')' if direct_key else 'MISSING'}"
+        )
+        if direct_key:
+            return "direct", {"direct_key": direct_key}
+        print(f"ERROR: Set {ENV_MINIMAX_KEY} for MiniMax image generation.", file=sys.stderr)
+        sys.exit(1)
+
     cf_account = os.environ.get(ENV_CF_ACCOUNT_ID, "").strip()
     cf_gateway = os.environ.get(ENV_CF_GATEWAY_ID, "").strip()
     cf_token = os.environ.get(ENV_CF_TOKEN, "").strip()
@@ -797,17 +850,20 @@ def build_gateway_url(provider: str, model: str, config: dict[str, str]) -> str:
     return url
 
 
-def build_direct_url(provider: str, model: str) -> str:
+def build_direct_url(provider: str, model: str, region: str = "global") -> str:
     """Build direct API URL for the given provider.
 
     Args:
-        provider: 'openrouter' or 'google'.
+        provider: Selected API provider.
         model: Model ID (used in Google URL path).
+        region: MiniMax API region.
 
     Returns:
         Full direct API URL string.
     """
-    if provider == "openrouter":
+    if provider == "minimax":
+        url = MINIMAX_ENDPOINTS[region]
+    elif provider == "openrouter":
         url = "https://openrouter.ai/api/v1/chat/completions"
     else:
         # Google's native API also wants the bare model id (no "google/" prefix).
@@ -846,7 +902,7 @@ def build_headers(provider: str, mode: str, config: dict[str, str]) -> dict[str,
             # direct_key, if present, is still used by the direct-mode fallback.
             headers["cf-aig-byok-alias"] = os.environ.get(ENV_CF_BYOK_ALIAS_OPENROUTER, "default").strip() or "default"
     else:
-        if provider == "openrouter":
+        if provider in ("openrouter", "minimax"):
             headers["Authorization"] = f"Bearer {config['direct_key']}"
         else:
             headers["x-goog-api-key"] = config["direct_key"]
@@ -874,11 +930,17 @@ def build_request_body(
     video_source: str | None = None,
     analysis_images: list[str] | None = None,
     json_schema: dict[str, Any] | None = None,
+    response_format: str = "url",
+    width: int | None = None,
+    height: int | None = None,
+    seed: int | None = None,
+    num_images: int | None = None,
+    prompt_optimizer: bool | None = None,
 ) -> dict[str, Any]:
     """Build JSON request body for the given provider.
 
     Args:
-        provider: 'openrouter' or 'google'.
+        provider: Selected API provider.
         model: Model ID string.
         prompt: The image generation prompt text.
         aspect_ratio: Optional aspect ratio (OpenRouter only), e.g. '16:9'.
@@ -898,11 +960,36 @@ def build_request_body(
         json_schema: Optional OpenRouter json_schema object (name/strict/schema).
             When set on a video request, adds response_format=json_schema and
             provider.require_parameters=true for strict structured output.
+        response_format: MiniMax output format, either URL or base64.
+        width: Optional MiniMax image width.
+        height: Optional MiniMax image height.
+        seed: Optional MiniMax generation seed.
+        num_images: Optional MiniMax image count.
+        prompt_optimizer: Optional MiniMax prompt optimizer toggle.
 
     Returns:
         Dict suitable for JSON serialization as request body.
     """
     refs = ref_images or []
+
+    if provider == "minimax":
+        if refs:
+            raise ValueError("MiniMax text-to-image requests do not accept reference images")
+        body: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "response_format": response_format,
+        }
+        optional_fields = {
+            "aspect_ratio": aspect_ratio,
+            "width": width,
+            "height": height,
+            "seed": seed,
+            "n": num_images,
+            "prompt_optimizer": prompt_optimizer,
+        }
+        body.update({key: value for key, value in optional_fields.items() if value is not None})
+        return body
 
     if provider == "openrouter" and video_source:
         # Video-analysis request: text prompt + a single video_url content part.
@@ -1200,6 +1287,46 @@ def extract_image_google(response: dict) -> tuple[bytes, str]:
         )
 
     return image_bytes, text_content
+
+
+def extract_image_minimax(response: dict) -> tuple[bytes, str]:
+    """Extract the first image from a MiniMax URL or base64 response."""
+    base_resp = response.get("base_resp", {})
+    status_code = base_resp.get("status_code", 0)
+    if status_code not in (0, "0"):
+        status_msg = base_resp.get("status_msg", "unknown error")
+        raise RuntimeError(f"MiniMax API error {status_code}: {status_msg}")
+
+    image_values = response.get("data", {}).get("image_urls", [])
+    if not image_values:
+        metadata = response.get("metadata", {})
+        raise RuntimeError(
+            "No images in MiniMax response "
+            f"(success_count={metadata.get('success_count', 0)}, "
+            f"failed_count={metadata.get('failed_count', 0)})"
+        )
+
+    image_value = image_values[0]
+    if not isinstance(image_value, str) or not image_value:
+        raise RuntimeError("Invalid image value in MiniMax response")
+
+    if image_value.startswith("https://"):
+        try:
+            with urllib.request.urlopen(image_value, timeout=60) as remote_image:
+                image_bytes = remote_image.read()
+        except (urllib.error.URLError, TimeoutError) as exc:
+            raise RuntimeError(f"MiniMax image download failed: {exc}") from exc
+    else:
+        encoded = image_value.split(",", 1)[1] if image_value.startswith("data:") else image_value
+        try:
+            image_bytes = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise RuntimeError("Invalid base64 image in MiniMax response") from exc
+
+    if not image_bytes:
+        raise RuntimeError("MiniMax returned an empty image")
+    log.info(f"Decoded MiniMax image: {len(image_bytes)} bytes")
+    return image_bytes, ""
 
 
 def extract_text_openrouter(response: dict) -> str:
@@ -1735,7 +1862,39 @@ def main() -> None:
         print("\nVideo presets:")
         for alias, kw in VIDEO_MODEL_PRESETS.items():
             print(f"  {alias:18s} -> {kw} ({VIDEO_MODEL_REGISTRY[kw]['id']})")
+        print("\nMiniMax image models:")
+        for model_id in sorted(MINIMAX_MODELS):
+            default = " (default)" if model_id == DEFAULT_MODELS["minimax"] else ""
+            print(f"  {model_id}{default}")
         sys.exit(0)
+
+    minimax_only_args = (
+        args.width,
+        args.height,
+        args.seed,
+        args.num_images,
+        args.prompt_optimizer,
+    )
+    if args.provider != "minimax" and any(value is not None for value in minimax_only_args):
+        print(
+            "ERROR: --width, --height, --seed, --num-images, and "
+            "--prompt-optimizer require --provider minimax",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if args.provider == "minimax":
+        if args.analyze or args.analyze_video:
+            print("ERROR: MiniMax integration supports text-to-image generation only", file=sys.stderr)
+            sys.exit(1)
+        if args.image_size:
+            print("ERROR: --image-size is not supported by the MiniMax API", file=sys.stderr)
+            sys.exit(1)
+        if args.num_images is not None and args.num_images < 1:
+            print("ERROR: --num-images must be at least 1", file=sys.stderr)
+            sys.exit(1)
+        if (args.width is None) != (args.height is None):
+            print("ERROR: --width and --height must be provided together", file=sys.stderr)
+            sys.exit(1)
 
     # Validate --analyze mode
     if args.analyze:
@@ -1988,7 +2147,7 @@ def main() -> None:
     if mode == "gateway":
         url = build_gateway_url(args.provider, model, config)
     else:
-        url = build_direct_url(args.provider, model)
+        url = build_direct_url(args.provider, model, args.minimax_region)
 
     headers = build_headers(args.provider, mode, config)
     body = build_request_body(
@@ -1997,6 +2156,12 @@ def main() -> None:
         ref_images=ref_images if ref_images else None,
         video_source=video_source,
         json_schema=VIDEO_JSON_SCHEMA if video_json_mode else None,
+        response_format=args.response_format,
+        width=args.width,
+        height=args.height,
+        seed=args.seed,
+        num_images=args.num_images,
+        prompt_optimizer=args.prompt_optimizer,
     )
 
     print(f"URL: {url}", file=sys.stderr)
@@ -2193,8 +2358,10 @@ def main() -> None:
     try:
         if args.provider == "openrouter":
             image_bytes, text_content = extract_image_openrouter(response)
-        else:
+        elif args.provider == "google":
             image_bytes, text_content = extract_image_google(response)
+        else:
+            image_bytes, text_content = extract_image_minimax(response)
     except RuntimeError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         log.debug(f"Image extraction failed. Raw response keys: {list(response.keys()) if response else 'None'}")

--- a/.claude/skills/ai-image-creator/scripts/generate-image.py
+++ b/.claude/skills/ai-image-creator/scripts/generate-image.py
@@ -595,6 +595,13 @@ def parse_args() -> argparse.Namespace:
         default="url",
         help="MiniMax response format (default: url)",
     )
+    parser.add_argument(
+        "--subject-reference",
+        action="append",
+        default=None,
+        metavar="URL",
+        help="MiniMax subject reference image URL (repeatable)",
+    )
     parser.add_argument("--width", type=int, default=None, help="MiniMax image width")
     parser.add_argument("--height", type=int, default=None, help="MiniMax image height")
     parser.add_argument("--seed", type=int, default=None, help="MiniMax generation seed")
@@ -936,6 +943,7 @@ def build_request_body(
     seed: int | None = None,
     num_images: int | None = None,
     prompt_optimizer: bool | None = None,
+    subject_references: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build JSON request body for the given provider.
 
@@ -966,6 +974,7 @@ def build_request_body(
         seed: Optional MiniMax generation seed.
         num_images: Optional MiniMax image count.
         prompt_optimizer: Optional MiniMax prompt optimizer toggle.
+        subject_references: Optional MiniMax subject reference image URLs.
 
     Returns:
         Dict suitable for JSON serialization as request body.
@@ -989,6 +998,11 @@ def build_request_body(
             "prompt_optimizer": prompt_optimizer,
         }
         body.update({key: value for key, value in optional_fields.items() if value is not None})
+        if subject_references:
+            body["subject_reference"] = [
+                {"type": "character", "image_file": image_url}
+                for image_url in subject_references
+            ]
         return body
 
     if provider == "openrouter" and video_source:
@@ -1874,11 +1888,12 @@ def main() -> None:
         args.seed,
         args.num_images,
         args.prompt_optimizer,
+        args.subject_reference,
     )
     if args.provider != "minimax" and any(value is not None for value in minimax_only_args):
         print(
             "ERROR: --width, --height, --seed, --num-images, and "
-            "--prompt-optimizer require --provider minimax",
+            "--prompt-optimizer/--subject-reference require --provider minimax",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -1894,6 +1909,11 @@ def main() -> None:
             sys.exit(1)
         if (args.width is None) != (args.height is None):
             print("ERROR: --width and --height must be provided together", file=sys.stderr)
+            sys.exit(1)
+        if args.subject_reference and any(
+            not image_url.startswith("https://") for image_url in args.subject_reference
+        ):
+            print("ERROR: --subject-reference must be an HTTPS image URL", file=sys.stderr)
             sys.exit(1)
 
     # Validate --analyze mode
@@ -2162,6 +2182,7 @@ def main() -> None:
         seed=args.seed,
         num_images=args.num_images,
         prompt_optimizer=args.prompt_optimizer,
+        subject_references=args.subject_reference,
     )
 
     print(f"URL: {url}", file=sys.stderr)

--- a/.claude/skills/ai-image-creator/tests/test_minimax_provider.py
+++ b/.claude/skills/ai-image-creator/tests/test_minimax_provider.py
@@ -1,0 +1,117 @@
+"""Tests for the MiniMax text-to-image provider."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "generate-image.py"
+SPEC = importlib.util.spec_from_file_location("generate_image", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+generate_image = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate_image)
+
+
+class MiniMaxProviderTests(unittest.TestCase):
+    def test_resolve_model_uses_default_and_accepts_live_model(self) -> None:
+        self.assertEqual(
+            generate_image.resolve_model(None, "minimax"),
+            ("image-01", ["image"]),
+        )
+        self.assertEqual(
+            generate_image.resolve_model("image-01-live", "minimax"),
+            ("image-01-live", ["image"]),
+        )
+
+    def test_direct_urls_cover_both_regions(self) -> None:
+        self.assertEqual(
+            generate_image.build_direct_url("minimax", "image-01", "global"),
+            "https://api.minimax.io/v1/image_generation",
+        )
+        self.assertEqual(
+            generate_image.build_direct_url("minimax", "image-01", "cn"),
+            "https://api.minimaxi.com/v1/image_generation",
+        )
+
+    def test_headers_use_bearer_authorization(self) -> None:
+        headers = generate_image.build_headers(
+            "minimax", "direct", {"direct_key": "test-value"}
+        )
+        self.assertEqual(headers["Authorization"], "Bearer test-value")
+
+    def test_request_body_includes_supported_text_to_image_fields(self) -> None:
+        body = generate_image.build_request_body(
+            "minimax",
+            "image-01-live",
+            "A lighthouse at dawn",
+            aspect_ratio="16:9",
+            response_format="base64",
+            width=1920,
+            height=1080,
+            seed=42,
+            num_images=2,
+            prompt_optimizer=False,
+        )
+        self.assertEqual(
+            body,
+            {
+                "model": "image-01-live",
+                "prompt": "A lighthouse at dawn",
+                "aspect_ratio": "16:9",
+                "width": 1920,
+                "height": 1080,
+                "response_format": "base64",
+                "seed": 42,
+                "n": 2,
+                "prompt_optimizer": False,
+            },
+        )
+
+    def test_extracts_base64_response(self) -> None:
+        expected = b"image-bytes"
+        response = {
+            "data": {"image_urls": [base64.b64encode(expected).decode()]},
+            "base_resp": {"status_code": 0},
+        }
+        self.assertEqual(
+            generate_image.extract_image_minimax(response),
+            (expected, ""),
+        )
+
+    def test_downloads_url_response(self) -> None:
+        class RemoteImage:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self) -> bytes:
+                return b"downloaded-image"
+
+        response = {
+            "data": {"image_urls": ["https://example.invalid/image.png"]},
+            "base_resp": {"status_code": 0},
+        }
+        with mock.patch.object(
+            generate_image.urllib.request, "urlopen", return_value=RemoteImage()
+        ):
+            self.assertEqual(
+                generate_image.extract_image_minimax(response),
+                (b"downloaded-image", ""),
+            )
+
+    def test_surfaces_api_error(self) -> None:
+        response = {
+            "base_resp": {"status_code": 1001, "status_msg": "request rejected"}
+        }
+        with self.assertRaisesRegex(RuntimeError, "request rejected"):
+            generate_image.extract_image_minimax(response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/ai-image-creator/tests/test_minimax_provider.py
+++ b/.claude/skills/ai-image-creator/tests/test_minimax_provider.py
@@ -55,6 +55,7 @@ class MiniMaxProviderTests(unittest.TestCase):
             seed=42,
             num_images=2,
             prompt_optimizer=False,
+            subject_references=["https://example.invalid/subject.png"],
         )
         self.assertEqual(
             body,
@@ -68,6 +69,12 @@ class MiniMaxProviderTests(unittest.TestCase):
                 "seed": 42,
                 "n": 2,
                 "prompt_optimizer": False,
+                "subject_reference": [
+                    {
+                        "type": "character",
+                        "image_file": "https://example.invalid/subject.png",
+                    }
+                ],
             },
         )
 


### PR DESCRIPTION
Reason: Add direct MiniMax text-to-image generation to the executable image-creator skill.

- add global and China endpoint selection with Bearer authentication
- support both image models and the documented text-to-image request controls
- decode URL and base64 responses with API error handling
- document setup and usage, with focused provider tests

Checks:

- `PYTHONDONTWRITEBYTECODE=1 uv run python -m unittest discover -s .claude/skills/ai-image-creator/tests -v`
- `PYTHONDONTWRITEBYTECODE=1 uv run python .claude/skills/ai-image-creator/scripts/generate-image.py --list-models`
- `PYTHONDONTWRITEBYTECODE=1 uv run python -c 'from pathlib import Path; p=Path(".claude/skills/ai-image-creator/scripts/generate-image.py"); compile(p.read_text(), str(p), "exec")'`
- `git diff --check`
